### PR TITLE
fix: should preserve labels and metadata when sealing

### DIFF
--- a/cmd/kinko/main.go
+++ b/cmd/kinko/main.go
@@ -141,8 +141,10 @@ func Seal(cmd *cobra.Command, args []string) error {
 
 		asset := &sealsv1alpha1.Asset{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      secret.Name,
-				Namespace: secret.Namespace,
+				Name:        secret.Name,
+				Namespace:   secret.Namespace,
+				Labels:      secret.Labels,
+				Annotations: secret.Annotations,
 			},
 			Spec: sealsv1alpha1.AssetSpec{
 				Type:          secret.Type,


### PR DESCRIPTION
## Description
Current implementation will drop labels and annotations information.

## What has been done
- pass labels and annotations to created assets